### PR TITLE
fix inconsistency with checkAuthorizationStatus return type

### DIFF
--- a/android/src/main/java/com/wix/RNCameraKit/camera/permission/CameraPermission.java
+++ b/android/src/main/java/com/wix/RNCameraKit/camera/permission/CameraPermission.java
@@ -58,6 +58,6 @@ public class CameraPermission {
     }
 
     private boolean isPermissionGranted(Activity activity) {
-        return checkAuthorizationStatus(activity) == PermissionChecker.PERMISSION_GRANTED;
+        return checkAuthorizationStatus(activity) == PERMISSION_GRANTED;
     }
 }


### PR DESCRIPTION
checkAuthorizationStatus returns local static finals
but within isPermissionGranted was compared against PermissionChecker consts which has different declarations
it caused requestDeviceCameraAuthorization to resolve before actual permissions was granted.